### PR TITLE
fix: manually trigger lsp index when prompt is added

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -567,6 +567,7 @@ export class ChatController {
 
                 const title = message.action.formItemValues?.['prompt-name']
                 const newFilePath = path.join(promptsDirectory, title ? `${title}.prompt` : 'default.prompt')
+                await LspClient.instance.updateIndex([newFilePath], 'add')
                 const newFileContent = new Uint8Array(Buffer.from(''))
                 await fs.writeFile(newFilePath, newFileContent)
                 const newFileDoc = await vscode.workspace.openTextDocument(newFilePath)


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
