### PR TITLE
fix: refresh prompt list when project prompt is added

### DIFF
--- a/packages/core/src/amazonq/lsp/lspController.ts
+++ b/packages/core/src/amazonq/lsp/lspController.ts
@@ -61,7 +61,7 @@ export interface Manifest {
         targets: Target[]
     }[]
 }
-const manifestUrl = 'https://ducvaeoffl85c.cloudfront.net/manifest-0.1.39.json'
+const manifestUrl = 'https://aws-toolkit-language-servers.amazonaws.com/q-context/manifest.json'
 // this LSP client in Q extension is only going to work with these LSP server versions
 const supportedLspServerVersions = ['0.1.39']
 

--- a/packages/core/src/amazonq/webview/ui/tabs/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/constants.ts
@@ -15,8 +15,6 @@ export type TabTypeData = {
 
 export const createPromptCommand = 'Create a new prompt'
 
-export const promptFileExtension = '.prompt'
-
 export const workspaceCommand: QuickActionCommandGroup = {
     groupName: 'Mention code',
     commands: [

--- a/packages/core/src/amazonq/webview/ui/tabs/constants.ts
+++ b/packages/core/src/amazonq/webview/ui/tabs/constants.ts
@@ -15,6 +15,8 @@ export type TabTypeData = {
 
 export const createPromptCommand = 'Create a new prompt'
 
+export const promptFileExtension = '.prompt'
+
 export const workspaceCommand: QuickActionCommandGroup = {
     groupName: 'Mention code',
     commands: [

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -883,11 +883,14 @@ export class ChatController {
         if (prompts.length > 0) {
             triggerPayload.additionalContents = []
             for (const prompt of prompts) {
-                triggerPayload.additionalContents.push({
-                    name: prompt.name,
-                    description: prompt.description,
-                    innerContext: prompt.content,
-                })
+                // Todo: add mechanism for sorting/prioritization of additional context
+                if (triggerPayload.additionalContents.length < 20 && prompt.content.length < 8000) {
+                    triggerPayload.additionalContents.push({
+                        name: prompt.name,
+                        description: prompt.description,
+                        innerContext: prompt.content,
+                    })
+                }
             }
             getLogger().info(
                 `Retrieved chunks of additional context count: ${triggerPayload.additionalContents.length} `

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -884,11 +884,11 @@ export class ChatController {
             triggerPayload.additionalContents = []
             for (const prompt of prompts) {
                 // Todo: add mechanism for sorting/prioritization of additional context
-                if (triggerPayload.additionalContents.length < 20 && prompt.content.length < 8000) {
+                if (triggerPayload.additionalContents.length < 20) {
                     triggerPayload.additionalContents.push({
-                        name: prompt.name,
-                        description: prompt.description,
-                        innerContext: prompt.content,
+                        name: prompt.name.substring(0, 1024),
+                        description: prompt.description.substring(0, 1024),
+                        innerContext: prompt.content.substring(0, 8192),
                     })
                 }
             }

--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -66,7 +66,7 @@ import { waitUntil } from '../../../shared/utilities/timeoutUtils'
 import { MynahIconsType, MynahUIDataModel, QuickActionCommand } from '@aws/mynah-ui'
 import { LspClient } from '../../../amazonq/lsp/lspClient'
 import { ContextCommandItem } from '../../../amazonq/lsp/types'
-import { createPromptCommand, promptFileExtension, workspaceCommand } from '../../../amazonq/webview/ui/tabs/constants'
+import { createPromptCommand, workspaceCommand } from '../../../amazonq/webview/ui/tabs/constants'
 import fs from '../../../shared/fs/fs'
 import * as vscode from 'vscode'
 import { FeatureConfigProvider, Features } from '../../../shared/featureConfig'
@@ -120,6 +120,12 @@ export interface ChatControllerMessageListeners {
     readonly processContextSelected: MessageListener<ContextSelectedMessage>
     readonly processFileClick: MessageListener<FileClick>
 }
+
+const promptFileExtension = '.prompt'
+
+const additionalContentInnerContextLimit = 8192
+
+const aditionalContentNameLimit = 1024
 
 export class ChatController {
     private readonly sessionStorage: ChatSessionStorage
@@ -886,9 +892,9 @@ export class ChatController {
                 // Todo: add mechanism for sorting/prioritization of additional context
                 if (triggerPayload.additionalContents.length < 20) {
                     triggerPayload.additionalContents.push({
-                        name: prompt.name.substring(0, 1024),
-                        description: prompt.description.substring(0, 1024),
-                        innerContext: prompt.content.substring(0, 8192),
+                        name: prompt.name.substring(0, aditionalContentNameLimit),
+                        description: prompt.description.substring(0, aditionalContentNameLimit),
+                        innerContext: prompt.content.substring(0, additionalContentInnerContextLimit),
                     })
                 }
             }


### PR DESCRIPTION
* switch lsp to prod endpoint
* do not use lsp to populate list of saved prompt files
* add validation for additionalContent (# of elements, and string lengths)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
