### PR TITLE
fix: clicking on workspace prompt files in context transparency

### DIFF
--- a/packages/core/src/codewhispererChat/controllers/chat/controller.ts
+++ b/packages/core/src/codewhispererChat/controllers/chat/controller.ts
@@ -463,11 +463,15 @@ export class ChatController {
 
         if (workspacePromptFiles.length > 0) {
             promptsCmd.children?.[0].commands.push(
-                ...workspacePromptFiles.map((file) => ({
-                    command: path.basename(file.path, promptFileExtension),
-                    icon: 'magic' as MynahIconsType,
-                    route: [path.dirname(file.path), path.basename(file.path)],
-                }))
+                ...workspacePromptFiles.map((file) => {
+                    const workspacePath = vscode.workspace.getWorkspaceFolder(file)?.uri.path || path.dirname(file.path)
+                    const relativePath = path.relative(workspacePath, file.path)
+                    return {
+                        command: path.basename(file.path, promptFileExtension),
+                        icon: 'magic' as MynahIconsType,
+                        route: [workspacePath, relativePath],
+                    }
+                })
             )
         }
         // Check ~/.aws/prompts for global prompt files


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
